### PR TITLE
reset_index only with MultiIndex or explicit index

### DIFF
--- a/pyplan_core/classes/wizards/DataframeIndex.py
+++ b/pyplan_core/classes/wizards/DataframeIndex.py
@@ -14,8 +14,10 @@ class Wizard(BaseWizard):
             currentDef = model.getNode(nodeId).definition
             newDef = self.getLastDefinition(currentDef)
             newDef = newDef + "\n# Set index"
+            
             reset_index = ""
-            if not isinstance(model.getNode(nodeId).result.index, pd.RangeIndex):
+            df = model.getNode(nodeId).result
+            if isinstance(df.index, pd.MultiIndex) or df.index.name is not None:  # df can be indexed by one column and it will not be a MultiIndex
                 reset_index = ".reset_index()"
 
             if not params is None and "columns" in params and len(params["columns"]) > 0:


### PR DESCRIPTION
An "un-indexed" dataframe can have different types of index objects: pandas.Index, pandas.RangeIndex, pandas.Int64Index and many more. 
It was better to check for:
    - MultiIndex (when there are 2 or more indexes)
    - If there is only one index, the default one doesn't have a name attribute, whereas if the index was set previously (i.e. df.set_index('Order ID')), there is a name attribute ('Order ID').