### PR TITLE
fix exports regional formatting

### DIFF
--- a/pyplan_core/classes/evaluators/BaseEvaluator.py
+++ b/pyplan_core/classes/evaluators/BaseEvaluator.py
@@ -189,7 +189,7 @@ class BaseEvaluator(object):
         import itertools
         allCombinations = itertools.product(*dimValues)
 
-        with open(fileName, 'w') as f:
+        with open(fileName, "w", encoding="utf-8-sig") as f:
             # headers
             f.write(columnFormat.join(realIndexes) + "\n")
             # data

--- a/pyplan_core/classes/evaluators/PandasEvaluator.py
+++ b/pyplan_core/classes/evaluators/PandasEvaluator.py
@@ -496,7 +496,7 @@ class PandasEvaluator(BaseEvaluator):
         _result = self.ensureDataFrame(nodeDic[nodeId].result)
 
         if isinstance(_result, pd.DataFrame):
-            _result.to_csv(fileName, sep=columnFormat, encoding="iso-8859-1")
+            _result.to_csv(fileName, sep=columnFormat, encoding="utf-8-sig")
 
             return True
 


### PR DESCRIPTION
According to https://docs.python.org/3/howto/unicode.html:

"In some areas, it is also convention to use a “BOM” at the start of UTF-8 encoded files; the name is misleading since UTF-8 is not byte-order dependent. The mark simply announces that the file is encoded in UTF-8. For reading such files, use the ‘utf-8-sig’ codec to automatically skip the mark if present."

Excel requires this BOM with UTF-8